### PR TITLE
fix: guard localStorage access in API clients

### DIFF
--- a/frontend/api/auth.js
+++ b/frontend/api/auth.js
@@ -7,7 +7,7 @@ const API = axios.create({
 
 // Attach JWT token to all requests if available
 API.interceptors.request.use(config => {
-  const token = localStorage.getItem('token');
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }

--- a/frontend/api/bounty.js
+++ b/frontend/api/bounty.js
@@ -7,7 +7,7 @@ const API = axios.create({
 
 // Attach JWT token to all requests if available
 API.interceptors.request.use(config => {
-  const token = localStorage.getItem('token');
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }

--- a/frontend/api/wallet.js
+++ b/frontend/api/wallet.js
@@ -7,7 +7,7 @@ const API = axios.create({
 
 // Attach JWT token to all requests if available
 API.interceptors.request.use(config => {
-  const token = localStorage.getItem('token');
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }


### PR DESCRIPTION
## Summary
- prevent server-side errors by checking for `window` before accessing `localStorage` in API clients

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68980c1aa9e08322b9ffec4d2423d900